### PR TITLE
Change to allow caller to set maximum element to drain from the queue

### DIFF
--- a/src/main/java/backtype/storm/contrib/cassandra/bolt/AbstractBatchingBolt.java
+++ b/src/main/java/backtype/storm/contrib/cassandra/bolt/AbstractBatchingBolt.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import backtype.storm.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +55,11 @@ public abstract class AbstractBatchingBolt implements IRichBolt,
 	@Override
 	public void prepare(Map stormConf, TopologyContext context,
 			OutputCollector collector) {
+		int batchMaxSize = Utils.getInt(Utils.get(stormConf, CASSANDRA_BATCH_MAX_SIZE, 0));
+
 		this.collector = collector;
 		this.queue = new LinkedBlockingQueue<Tuple>();
-		this.batchThread = new BatchThread();
+		this.batchThread = new BatchThread(batchMaxSize);
 		this.batchThread.start();
 	}
 	
@@ -95,11 +98,17 @@ public abstract class AbstractBatchingBolt implements IRichBolt,
 
 	private class BatchThread extends Thread {
 
+		int batchMaxSize;
 		boolean stopRequested = false;
 
-		BatchThread() {
+        BatchThread() {
+			this(0);
+		}
+		
+		BatchThread(int batchMaxSize) {
 			super("batch-bolt-thread");
 			super.setDaemon(true);
+			this.batchMaxSize = batchMaxSize;
 		}
 
 		@Override
@@ -110,7 +119,12 @@ public abstract class AbstractBatchingBolt implements IRichBolt,
 			        // drainTo() does not block, take() does.
 			        Tuple t = queue.take();
 			        batch.add(t);
-	                queue.drainTo(batch);
+					if (batchMaxSize > 0) {
+						queue.drainTo(batch, batchMaxSize);
+					}
+					else {
+						queue.drainTo(batch);
+					}
 	                executeBatch(batch);
                     
                 }

--- a/src/main/java/backtype/storm/contrib/cassandra/bolt/CassandraConstants.java
+++ b/src/main/java/backtype/storm/contrib/cassandra/bolt/CassandraConstants.java
@@ -4,4 +4,5 @@ public interface CassandraConstants {
 	public static String CASSANDRA_HOST = "cassandra.host";
 	public static final String CASSANDRA_PORT = "cassandra.port";
 	public static final String CASSANDRA_KEYSPACE = "cassandra.keyspace";
+	public static final String CASSANDRA_BATCH_MAX_SIZE = "cassandra.batch.max_size";
 }


### PR DESCRIPTION
Hi Goetz,

I made the change to implement this issue https://github.com/ptgoetz/storm-cassandra/issues/6
The change is to allow caller to be able to limit the maximum elements that he wants to drain from the queue so that he can avoid from out of memory issue when there are two many elements in the queue.
My implementation is get this setting from Config object (The same as hosts and port...). If there is no setting for this parameter or the value is less than or equal zero then the API just behaves the same as it was before but if there is setting and the value is greater than zero then the API will drain up to the limit of elements from the queue.
Can you please check and let me know if you have any concern?

Thanks
Binh
