### PR TITLE
Consistently stringify key components in map state

### DIFF
--- a/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraMapState.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraMapState.java
@@ -235,7 +235,8 @@ public class CassandraMapState<T> implements IBackingMap<T> {
 
         List<T> values = new ArrayList<T>();
         for (List<Object> key : keys) {
-            byte[] bytes = resultMap.get(key);
+            List<String> stringKey = toKeyStrings(key);
+            byte[] bytes = resultMap.get(stringKey);
             if (bytes != null) {
                 values.add(serializer.deserialize(bytes));
             } else {
@@ -279,12 +280,22 @@ public class CassandraMapState<T> implements IBackingMap<T> {
 
     private Composite toKeyName(List<Object> key) {
         Composite keyName = new Composite();
-        for (Object component : key) {
+        List<String> keyStrings = toKeyStrings(key);
+        for (String componentString : keyStrings) {
+            keyName.addComponent(componentString, StringSerializer.get());
+        }
+        return keyName;
+    }
+
+    private ArrayList<String> toKeyStrings(List<Object> key) {
+        ArrayList keyStrings = new ArrayList<String>();
+        for (int i = 0; i < key.size(); i++){
+            Object component = key.get(i);
             if (component == null) {
                 component = "[NULL]";
             }
-            keyName.addComponent(component.toString(), StringSerializer.get());
+            keyStrings.add(component.toString());
         }
-        return keyName;
+        return keyStrings;
     }
 }


### PR DESCRIPTION
This fixes an edge case of key handling in `CassandraMapState.multiGet`, when a component of a key isn't a string. On write the row key components are stringified, and on read the components are again correctly stringified for querying from C*, but [soon after](https://github.com/hmsonline/storm-cassandra/blob/master/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraMapState.java#L238)  when pulling the queried values from the result map`multiGet` erroneously uses the un-stringified components. The unit tests passed because they only have keys whose sole component is a string.

I split the `toKeyNames` logic into a reusable method `toKeyStrings` which returns an array list instead of a `Component`.
