### PR TITLE
CassandraCounterBatchingBolt takes Type parameters

### DIFF
--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/CassandraCounterBatchingBolt.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/CassandraCounterBatchingBolt.java
@@ -15,15 +15,16 @@ public class CassandraCounterBatchingBolt<K, C, V> extends AbstractBatchingBolt<
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(CassandraCounterBatchingBolt.class);
 
-    private TupleCounterMapper tupleMapper;
+    private TupleCounterMapper<K, C> tupleMapper;
 
-    public CassandraCounterBatchingBolt(String clientConfigKey, TupleCounterMapper tupleMapper) {
+    public CassandraCounterBatchingBolt(String clientConfigKey, TupleCounterMapper<K, C> tupleMapper) {
         super(clientConfigKey, null);
         this.tupleMapper = tupleMapper;
     }
 
-    public CassandraCounterBatchingBolt(String keyspace, String clientConfigKey, String columnFamily, String rowKeyField, String incrementAmountField) {
-        this(clientConfigKey, new DefaultTupleCounterMapper(keyspace, columnFamily, rowKeyField, incrementAmountField));
+    @SuppressWarnings("unchecked")
+	public CassandraCounterBatchingBolt(String keyspace, String clientConfigKey, String columnFamily, String rowKeyField, String incrementAmountField) {
+        this(clientConfigKey, (TupleCounterMapper<K, C>) new DefaultTupleCounterMapper(keyspace, columnFamily, rowKeyField, incrementAmountField) );
     }
 
     @Override

--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/DefaultTupleCounterMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/DefaultTupleCounterMapper.java
@@ -12,7 +12,7 @@ import backtype.storm.tuple.Tuple;
  * must be specified: rowKey, and incrementAmount, all remaining fields are
  * assumed to be column names to be incremented by the specified amount.
  */
-public class DefaultTupleCounterMapper implements TupleCounterMapper {
+public class DefaultTupleCounterMapper implements TupleCounterMapper<String,String> {
 
     private static final long serialVersionUID = 1L;
     private String rowKeyField;
@@ -59,5 +59,15 @@ public class DefaultTupleCounterMapper implements TupleCounterMapper {
         }
         return result;
     }
+
+	@Override
+	public Class<String> getKeyClass() {
+		return String.class;
+	}
+
+	@Override
+	public Class<String> getColumnNameClass() {
+		return String.class;
+	}
 
 }

--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/TupleCounterMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/TupleCounterMapper.java
@@ -11,7 +11,7 @@ import backtype.storm.tuple.Tuple;
  * @author tgoetz
  *
  */
-public interface TupleCounterMapper extends Serializable {
+public interface TupleCounterMapper<K, C> extends Serializable {
 
     /**
      * Given a <code>backtype.storm.tuple.Tuple</code> object, map the column
@@ -37,7 +37,7 @@ public interface TupleCounterMapper extends Serializable {
      * @param tuple
      * @return
      */
-    String mapToRowKey(Tuple tuple);
+    K mapToRowKey(Tuple tuple);
 
     /**
      * Given a <code>backtype.storm.tuple.Tuple</code> return the amount that
@@ -55,6 +55,20 @@ public interface TupleCounterMapper extends Serializable {
      * @param tuple
      * @return
      */
-    List<String> mapToColumnList(Tuple tuple);
-
+    List<C> mapToColumnList(Tuple tuple);
+    
+    /**
+     * Returns the row key class
+     * 
+     * @return
+     */
+    Class<K> getKeyClass();
+    
+    /**
+     * Returns the column name class
+     * 
+     * @return
+     */
+    Class<C> getColumnNameClass();
+    
 }

--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
@@ -410,21 +410,24 @@ public class AstyanaxClient<K, C, V> {
         }
     }
 
-    public void incrementCountColumn(Tuple input, TupleCounterMapper tupleMapper) throws Exception {
+    @SuppressWarnings("unchecked")
+	public void incrementCountColumn(Tuple input, TupleCounterMapper<K,C> tupleMapper) throws Exception {
         String columnFamilyName = tupleMapper.mapToColumnFamily(input);
         String keyspace = tupleMapper.mapToKeyspace(input);
-        String rowKey = (String) tupleMapper.mapToRowKey(input);
+        K rowKey = tupleMapper.mapToRowKey(input);
         long incrementAmount = tupleMapper.mapToIncrementAmount(input);
         MutationBatch mutation = getKeyspace(keyspace).prepareMutationBatch();
-        ColumnFamily<String, String> columnFamily = new ColumnFamily<String, String>(columnFamilyName,
-                StringSerializer.get(), StringSerializer.get());
-        for (String columnName : tupleMapper.mapToColumnList(input)) {
+        ColumnFamily<K, C> columnFamily = new ColumnFamily<K, C>(columnFamilyName,
+                (Serializer<K>) serializerFor(tupleMapper.getKeyClass()),
+                (Serializer<C>) serializerFor(tupleMapper.getColumnNameClass()));
+        for (C columnName : tupleMapper.mapToColumnList(input)) {
             mutation.withRow(columnFamily, rowKey).incrementCounterColumn(columnName, incrementAmount);
         }
         mutation.execute();
     }
 
-    public void incrementCountColumns(List<Tuple> inputs, TupleCounterMapper tupleMapper) throws Exception {    
+    @SuppressWarnings("unchecked")
+	public void incrementCountColumns(List<Tuple> inputs, TupleCounterMapper<K,C> tupleMapper) throws Exception {    
         Map<String, MutationBatch> mutations = new HashMap<String, MutationBatch>();
         for (Tuple input : inputs) {
             String keyspace = tupleMapper.mapToKeyspace(input);            
@@ -434,11 +437,12 @@ public class AstyanaxClient<K, C, V> {
                 mutations.put(keyspace, mutation);
             }
             String columnFamilyName = tupleMapper.mapToColumnFamily(input);
-            String rowKey = (String) tupleMapper.mapToRowKey(input);
+            K rowKey = tupleMapper.mapToRowKey(input);
             long incrementAmount = tupleMapper.mapToIncrementAmount(input);
-            ColumnFamily<String, String> columnFamily = new ColumnFamily<String, String>(columnFamilyName,
-                    StringSerializer.get(), StringSerializer.get());
-            for (String columnName : tupleMapper.mapToColumnList(input)) {
+            ColumnFamily<K, C> columnFamily = new ColumnFamily<K, C>(columnFamilyName,
+                    (Serializer<K>) serializerFor(tupleMapper.getKeyClass()),
+                    (Serializer<C>) serializerFor(tupleMapper.getColumnNameClass()));
+            for (C columnName : tupleMapper.mapToColumnList(input)) {
                 mutation.withRow(columnFamily, rowKey).incrementCounterColumn(columnName, incrementAmount);
             }
         }

--- a/src/test/java/com/hmsonline/storm/cassandra/bolt/CassandraBoltTest.java
+++ b/src/test/java/com/hmsonline/storm/cassandra/bolt/CassandraBoltTest.java
@@ -99,7 +99,7 @@ public class CassandraBoltTest {
     @Test
     public void testCounterBolt() throws Exception {
         String configKey = "cassandra-config";
-        CassandraCounterBatchingBolt<String, String, String> bolt = new CassandraCounterBatchingBolt<String, String, String>(KEYSPACE, configKey, "Counts", "Timestamp", "IncrementAmount");
+        CassandraCounterBatchingBolt<String, String,Long> bolt = new CassandraCounterBatchingBolt<String, String, Long>(KEYSPACE, configKey, "Counts", "Timestamp", "IncrementAmount");
         TopologyBuilder builder = new TopologyBuilder();
         builder.setBolt("TEST__COUNTER_BOLT", bolt);
 
@@ -118,7 +118,7 @@ public class CassandraBoltTest {
         bolt.prepare(config, context, null);
         System.out.println("Bolt Preparation Complete.");
 
-        Values values = new Values(1L, 1L, "MyCountColumn");
+        Values values = new Values("1", 1L, "MyCountColumn");
         Tuple tuple = new TupleImpl(context, values, 5, "test");
         bolt.execute(tuple);
 


### PR DESCRIPTION
This allows CassandraCounterBatchingBolt to write to rows that have
rowkeys with a type other than string.

Had also to correct the TupleCounterMapper and the Astyanax client.

The DefaultTupleCounterMaper uses String for rowkeys and columnkeys.

Corrected the CassandraBoltTest to work with this alterations.
