### PR TITLE
add CompositeRowTupleMapper

### DIFF
--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
@@ -1,8 +1,8 @@
 package com.hmsonline.storm.cassandra.bolt.mapper;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Arrays;
 
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
@@ -20,6 +20,8 @@ public class CompositeRowTupleMapper implements TupleMapper<Composite, String, S
      * This mapper is similar to the DefaultTupleMapper, but supports composite row keys
      * constructed from multiple fields.
      *
+     * @param keyspace
+     *            keyspace to write to.
      * @param columnFamily
      *            column family to write to.
      * @param rowKeyFields
@@ -57,7 +59,7 @@ public class CompositeRowTupleMapper implements TupleMapper<Composite, String, S
      * in the Cassandra row, excluding fields that were included in the row.
      *
      * @param tuple
-     * @return
+     * @return map of columns to values
      */
     @Override
     public Map<String, String> mapToColumns(Tuple tuple) {
@@ -65,11 +67,11 @@ public class CompositeRowTupleMapper implements TupleMapper<Composite, String, S
         Map<String, String> columns = new HashMap<String, String>();
         for (int i = 0; i < fields.size(); i++) {
             String name = fields.get(i);
-	    Boolean isRowField = Arrays.asList(this.rowKeyFields).contains(name);
-	    if (!isRowField) {
-		Object value = tuple.getValueByField(name);
-		columns.put(name, (value != null ? value.toString() : ""));
-	    }
+            Boolean isRowField = Arrays.asList(this.rowKeyFields).contains(name);
+            if (!isRowField) {
+                Object value = tuple.getValueByField(name);
+                columns.put(name, (value != null ? value.toString() : ""));
+            }
         }
         return columns;
     }

--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
@@ -1,0 +1,97 @@
+package com.hmsonline.storm.cassandra.bolt.mapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+
+import com.netflix.astyanax.model.Composite;
+import com.netflix.astyanax.serializers.StringSerializer;
+
+public class CompositeRowTupleMapper implements TupleMapper<Composite, String, String> {
+    private static final long serialVersionUID = 1L;
+    private String[] rowKeyFields;
+    private String columnFamily;
+    private String keyspace;
+
+    /**
+     * This mapper is similar to the DefaultTupleMapper, but supports composite row keys
+     * constructed from multiple fields.
+     *
+     * @param columnFamily
+     *            column family to write to.
+     * @param rowKeyFields
+     *            tuple fields to use as the composite row key.
+     */
+    public CompositeRowTupleMapper(String keyspace, String columnFamily, String... rowKeyFields) {
+        this.rowKeyFields = rowKeyFields;
+        this.columnFamily = columnFamily;
+        this.keyspace = keyspace;
+    }
+
+    @Override
+    public Composite mapToRowKey(Tuple tuple) {
+        Composite keyName = new Composite();
+
+        for (String rowKeyField : this.rowKeyFields){
+            Object component = tuple.getValueByField(rowKeyField);
+            if (component == null) {
+                component = "[NULL]";
+            }
+
+            keyName.addComponent(component.toString(), StringSerializer.get());
+        }
+
+        return keyName;
+    }
+
+    @Override
+    public String mapToKeyspace(Tuple tuple) {
+        return this.keyspace;
+    }
+
+    /**
+     * Default behavior is to write each value in the tuple as a key:value pair
+     * in the Cassandra row.
+     *
+     * @param tuple
+     * @return
+     */
+    @Override
+    public Map<String, String> mapToColumns(Tuple tuple) {
+        Fields fields = tuple.getFields();
+        Map<String, String> columns = new HashMap<String, String>();
+        for (int i = 0; i < fields.size(); i++) {
+            String name = fields.get(i);
+            Object value = tuple.getValueByField(name);
+            columns.put(name, (value != null ? value.toString() : ""));
+        }
+        return columns;
+    }
+
+    @Override
+    public String mapToColumnFamily(Tuple tuple) {
+        return this.columnFamily;
+    }
+
+    @Override
+    public Class<Composite> getKeyClass() {
+        // TODO Auto-generated method stub
+        return Composite.class;
+    }
+
+    @Override
+    public Class<String> getColumnNameClass() {
+        // TODO Auto-generated method stub
+        return String.class;
+    }
+
+    @Override
+    public Class<String> getColumnValueClass() {
+        // TODO Auto-generated method stub
+        return String.class;
+    }
+
+
+}

--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/CompositeRowTupleMapper.java
@@ -2,6 +2,7 @@ package com.hmsonline.storm.cassandra.bolt.mapper;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Arrays;
 
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Tuple;
@@ -52,8 +53,8 @@ public class CompositeRowTupleMapper implements TupleMapper<Composite, String, S
     }
 
     /**
-     * Default behavior is to write each value in the tuple as a key:value pair
-     * in the Cassandra row.
+     * Write each value in the tuple as a key:value pair
+     * in the Cassandra row, excluding fields that were included in the row.
      *
      * @param tuple
      * @return
@@ -64,8 +65,11 @@ public class CompositeRowTupleMapper implements TupleMapper<Composite, String, S
         Map<String, String> columns = new HashMap<String, String>();
         for (int i = 0; i < fields.size(); i++) {
             String name = fields.get(i);
-            Object value = tuple.getValueByField(name);
-            columns.put(name, (value != null ? value.toString() : ""));
+	    Boolean isRowField = Arrays.asList(this.rowKeyFields).contains(name);
+	    if (!isRowField) {
+		Object value = tuple.getValueByField(name);
+		columns.put(name, (value != null ? value.toString() : ""));
+	    }
         }
         return columns;
     }

--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
@@ -48,6 +48,7 @@ import com.netflix.astyanax.model.ByteBufferRange;
 import com.netflix.astyanax.model.Column;
 import com.netflix.astyanax.model.ColumnFamily;
 import com.netflix.astyanax.model.ColumnList;
+import com.netflix.astyanax.model.Composite;
 import com.netflix.astyanax.query.RowQuery;
 import com.netflix.astyanax.serializers.AnnotatedCompositeSerializer;
 import com.netflix.astyanax.serializers.BigIntegerSerializer;
@@ -56,6 +57,7 @@ import com.netflix.astyanax.serializers.ByteBufferSerializer;
 import com.netflix.astyanax.serializers.ByteSerializer;
 import com.netflix.astyanax.serializers.BytesArraySerializer;
 import com.netflix.astyanax.serializers.CompositeRangeBuilder;
+import com.netflix.astyanax.serializers.CompositeSerializer;
 import com.netflix.astyanax.serializers.DateSerializer;
 import com.netflix.astyanax.serializers.DoubleSerializer;
 import com.netflix.astyanax.serializers.FloatSerializer;
@@ -571,7 +573,10 @@ public class AstyanaxClient<K, C, V> {
             serializer = ByteBufferSerializer.get();
         } else if (valueClass.equals(Date.class)) {
             serializer = DateSerializer.get();
+        } else if (valueClass.equals(Composite.class)) {
+            serializer = CompositeSerializer.get();
         }
+
         if (serializer == null) {
             if (containsComponentAnnotation(valueClass)) {
                 serializer = new AnnotatedCompositeSerializer(valueClass);


### PR DESCRIPTION
This adds a new tuple mapper which is like the `DefaultTupleMapper` but accommodates composite row keys. Values from row fields are _not_ included as columns.

`CompositeRowTupleMapper` uses a variadic constructor, so as to be a drop-in replacement for `DefaultTupleMapper`.
