### PR TITLE
Upgrade to 0.9.0-rc2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 	</repositories>
 
 	<properties>
-		<storm.version>0.8.2</storm.version>
+		<storm.version>0.9.0-rc2</storm.version>
 		<cassandra.version>1.2.5</cassandra.version>
 	</properties>
 

--- a/src/test/java/com/hmsonline/storm/cassandra/bolt/MockTopologyContext.java
+++ b/src/test/java/com/hmsonline/storm/cassandra/bolt/MockTopologyContext.java
@@ -13,7 +13,7 @@ public class MockTopologyContext extends TopologyContext {
 
     public MockTopologyContext(StormTopology topology, Fields fields) {
         super(topology, new HashMap<String, String>(), new HashMap<Integer, String>(), null, null, null, null, null,
-                -1, -1, new ArrayList<Integer>(), null, null, null);
+                -1, -1, new ArrayList<Integer>(), null, null, null, null, null);
         this.declaredFields = fields;
     }
 


### PR DESCRIPTION
Interesting observation... 

I was receiving this:
 WARN (org.apache.zookeeper.server.ZooKeeperServer:372) - Failed to register with JMX
javax.management.InstanceAlreadyExistsException: org.apache.ZooKeeperService:name0=StandaloneServer_port-1

Which may be related to this:
http://isharapremadasa.blogspot.com/2013/07/avoiding-javaxmanagementinstancealready.html

(using JDK7 on OS X 10.9)

Before I dug too deep, I wanted to see if it was isolated to the specific version of Storm.  I upgraded the dependency and fixed the MockTopologyContext to match, and the issue went away.  

I have _NOT_ tested deploying this with the 0.9, but figured I would create an issue for the upgrade so we can get it in there.
