### PR TITLE
Storm cassandra connection pool sharing

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.hmsonline</groupId>
 	<artifactId>storm-cassandra-examples</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.4.0-rc4-SNAPSHOT</version>
 	<name>Storm Cassandra Examples</name>
 	<description>Storm Cassandra Examples</description>
 	<repositories>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.hmsonline</groupId>
 			<artifactId>storm-cassandra</artifactId>
-			<version>0.4.0-SNAPSHOT</version>
+			<version>0.4.0-rc4-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>storm</groupId>

--- a/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/DefaultTupleMapper.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/bolt/mapper/DefaultTupleMapper.java
@@ -15,6 +15,8 @@ public class DefaultTupleMapper implements TupleMapper<String, String, String> {
     /**
      * Construct default mapper.
      * 
+     * @param keyspace
+     *            keyspace to use.
      * @param columnFamily
      *            column family to write to.
      * @param rowKeyField

--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClientFactory.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClientFactory.java
@@ -23,30 +23,31 @@ public class AstyanaxClientFactory {
     }
 	
 	/**
-	 * @param configKey only one client will be created per config key
-	 * @param conf the config map for the given configKey
-	 * @return AstyanaxClient that maps to a configKey
+	 * @param cassandraClusterId only one instance will be available per Cassandra Cluster identifer
+	 * @param conf the configuration for the given cassandraClusterId
+	 * @return AstyanaxClient that maps to a cassandraClusterId
 	 */
 	@SuppressWarnings("rawtypes")
-	public static AstyanaxClient getInstance(String configKey, Map conf) {
-		if (clients.containsKey(configKey)) {
-			LOG.debug("Returning existing client for configKey " + configKey);
-			return clients.get(configKey);
+	public static AstyanaxClient getInstance(String cassandraClusterId, Map conf) {
+		if (clients.containsKey(cassandraClusterId)) {
+			LOG.debug("Returning existing instance that maps to cassandra cluster " + cassandraClusterId);
+			return clients.get(cassandraClusterId);
 		} else {
-			return createClient(configKey, conf);
+			return createClient(cassandraClusterId, conf);
 		}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private synchronized static AstyanaxClient createClient(String configKey, Map conf) {
-		// in case > 1 factory client with same configKey arrive here
-		if (clients.containsKey(configKey)) {
-			return clients.get(configKey);
+	private synchronized static AstyanaxClient createClient(String cassandraClusterId, Map conf) {
+		// in case > 1 factory client with same cassandraClusterId arrive here
+		if (clients.containsKey(cassandraClusterId)) {
+			LOG.debug("Returning existing instance that maps to cassandra cluster " + cassandraClusterId);
+			return clients.get(cassandraClusterId);
 		}
-		LOG.debug("Creating new AstyanaxClient for configKey " + configKey + " and starting with config " + conf);
+		LOG.debug("Creating new AstyanaxClient instance for cassandra cluster " + cassandraClusterId + " and starting with config " + conf);
 		AstyanaxClient client = new AstyanaxClient();
 		client.start(conf);
-		clients.put(configKey, client);
+		clients.put(cassandraClusterId, client);
 		return client;
 	}
 }

--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClientFactory.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClientFactory.java
@@ -1,0 +1,52 @@
+package com.hmsonline.storm.cassandra.client;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author jtyack
+ * Factory ensures that one AstyanaxClient exists per configKey
+ *
+ */
+public class AstyanaxClientFactory {
+	
+    private static final Logger LOG = LoggerFactory.getLogger(AstyanaxClientFactory.class);
+	
+	@SuppressWarnings("rawtypes")
+	private static Map<String, AstyanaxClient> clients = new ConcurrentHashMap<String, AstyanaxClient>();
+
+	// factory clients cannot instantiate
+	private AstyanaxClientFactory(){
+    }
+	
+	/**
+	 * @param configKey only one client will be created per config key
+	 * @param conf the config map for the given configKey
+	 * @return AstyanaxClient that maps to a configKey
+	 */
+	@SuppressWarnings("rawtypes")
+	public static AstyanaxClient getInstance(String configKey, Map conf) {
+		if (clients.containsKey(configKey)) {
+			LOG.debug("Returning existing client for configKey " + configKey);
+			return clients.get(configKey);
+		} else {
+			return createClient(configKey, conf);
+		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private synchronized static AstyanaxClient createClient(String configKey, Map conf) {
+		// in case > 1 factory client with same configKey arrive here
+		if (clients.containsKey(configKey)) {
+			return clients.get(configKey);
+		}
+		LOG.debug("Creating new AstyanaxClient for configKey " + configKey + " and starting with config " + conf);
+		AstyanaxClient client = new AstyanaxClient();
+		client.start(conf);
+		clients.put(configKey, client);
+		return client;
+	}
+}

--- a/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
@@ -2,18 +2,18 @@ package com.hmsonline.storm.cassandra.trident;
 
 import java.util.Map;
 
-import com.hmsonline.storm.cassandra.exceptions.ExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.hmsonline.storm.cassandra.StormCassandraConstants;
-import com.hmsonline.storm.cassandra.bolt.mapper.TridentTupleMapper;
-import com.hmsonline.storm.cassandra.client.AstyanaxClient;
-
-import backtype.storm.task.IMetricsContext;
-import backtype.storm.utils.Utils;
 import storm.trident.state.State;
 import storm.trident.state.StateFactory;
+import backtype.storm.task.IMetricsContext;
+import backtype.storm.utils.Utils;
+
+import com.hmsonline.storm.cassandra.StormCassandraConstants;
+import com.hmsonline.storm.cassandra.client.AstyanaxClient;
+import com.hmsonline.storm.cassandra.client.AstyanaxClientFactory;
+import com.hmsonline.storm.cassandra.exceptions.ExceptionHandler;
 
 public class CassandraStateFactory implements StateFactory {
 
@@ -37,8 +37,7 @@ public class CassandraStateFactory implements StateFactory {
     @Override
     public State makeState(Map conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
         LOG.debug("makeState partitionIndex:{} numPartitions:{}", partitionIndex, numPartitions);
-        AstyanaxClient client = new AstyanaxClient();
-        client.start((Map) conf.get(this.configKey));
+        AstyanaxClient client = AstyanaxClientFactory.getInstance(configKey, (Map)conf.get(configKey));
         int batchMaxSize = Utils.getInt(Utils.get(conf, StormCassandraConstants.CASSANDRA_BATCH_MAX_SIZE,
                 CassandraState.DEFAULT_MAX_BATCH_SIZE));
         return new CassandraState(client, batchMaxSize, this.exceptionHandler);

--- a/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
@@ -24,8 +24,11 @@ public class CassandraStateFactory implements StateFactory {
     private String cassandraClusterId;
     private ExceptionHandler exceptionHandler;
 
-    public CassandraStateFactory(String configKey){
-        this(configKey, null);
+    /**
+     * @param  Identifier that uniquely identifies the Cassandra Cluster
+     */
+    public CassandraStateFactory(String cassandraClusterId) {
+        this(cassandraClusterId, null);
     }
 
     /**

--- a/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/trident/CassandraStateFactory.java
@@ -21,23 +21,30 @@ public class CassandraStateFactory implements StateFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(CassandraStateFactory.class);
 
-    private String configKey;
+    private String cassandraClusterId;
     private ExceptionHandler exceptionHandler;
 
     public CassandraStateFactory(String configKey){
         this(configKey, null);
     }
 
-    public CassandraStateFactory(String configKey, ExceptionHandler exceptionHandler) {
-        this.configKey = configKey;
+    /**
+     * @param cassandraClusterId Identifier that uniquely identifies the Cassandra Cluster
+     * @param exceptionHandler
+     */
+    public CassandraStateFactory(String cassandraClusterId, ExceptionHandler exceptionHandler) {
+        this.cassandraClusterId = cassandraClusterId;
         this.exceptionHandler = exceptionHandler;
     }
 
+    /* (non-Javadoc)
+     * @see storm.trident.state.StateFactory#makeState(java.util.Map, backtype.storm.task.IMetricsContext, int, int)
+     */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public State makeState(Map conf, IMetricsContext metrics, int partitionIndex, int numPartitions) {
-        LOG.debug("makeState partitionIndex:{} numPartitions:{}", partitionIndex, numPartitions);
-        AstyanaxClient client = AstyanaxClientFactory.getInstance(configKey, (Map)conf.get(configKey));
+        LOG.info("Making new CassandraState object for cluster " + cassandraClusterId + ": partition [" + partitionIndex + "] of [" + numPartitions + "]");
+        AstyanaxClient client = AstyanaxClientFactory.getInstance(cassandraClusterId, (Map)conf.get(cassandraClusterId));
         int batchMaxSize = Utils.getInt(Utils.get(conf, StormCassandraConstants.CASSANDRA_BATCH_MAX_SIZE,
                 CassandraState.DEFAULT_MAX_BATCH_SIZE));
         return new CassandraState(client, batchMaxSize, this.exceptionHandler);


### PR DESCRIPTION
New AstyanaxClient factory that creates a single instance per Cassandra cluster.  Previously, instances were being created on every makeState call to CassandraStateFactory. 

The code has been re-factored slightly to make it clear that the previously named 'configKey' represents a C\* cluster identifier.
