### PR TITLE
Casting error when setting CASSANDRA_PORT explicitly

### DIFF
--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
@@ -110,9 +110,9 @@ public class AstyanaxClient<K, C, V> {
             ConnectionPoolConfigurationImpl cpConfig = (ConnectionPoolConfigurationImpl) settings
                     .get(ASTYANAX_CONNECTION_POOL_CONFIGURATION);
             cpConfig.setSeeds((String) config.get(StormCassandraConstants.CASSANDRA_HOST));
-            Integer port = (Integer)config.get(StormCassandraConstants.CASSANDRA_PORT);
+            Long port = (Long)config.get(StormCassandraConstants.CASSANDRA_PORT);
             if(port != null){
-            	cpConfig.setPort(port);
+            	cpConfig.setPort(port.intValue());
             }
         }
 


### PR DESCRIPTION
I get some weird auto-unboxing error when setting CASSANDRA_PORT explicitly.

I use:

``` java
clientConfig.put(StormCassandraConstants.CASSANDRA_PORT, (Integer) port);
```

But somehow in Astyanax client it gets unboxed to Long, which results in a casting error.  Im using openjdk 7 on linux, but experienced the same for jdk7 on winodws. 
