### PR TITLE
Support configuration of ttl from AstyanaxClient

### DIFF
--- a/src/main/java/com/hmsonline/storm/cassandra/StormCassandraConstants.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/StormCassandraConstants.java
@@ -8,6 +8,7 @@ public class StormCassandraConstants {
     public static final String CASSANDRA_HOST = "cassandra.host";
     public static final String CASSANDRA_PORT = "cassandra.port";
     public static final String CASSANDRA_KEYSPACE = "cassandra.keyspace";
+    public static final String CASSANDRA_TTL = "cassandra.ttl";
     public static final String CASSANDRA_STATE_KEYSPACE = "cassandra.state.keyspace";
     public static final String CASSANDRA_BATCH_MAX_SIZE = "cassandra.batch.max_size";
     public static final String CASSANDRA_CLIENT_CLASS = "cassandra.client.class";

--- a/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
+++ b/src/main/java/com/hmsonline/storm/cassandra/client/AstyanaxClient.java
@@ -82,8 +82,7 @@ public class AstyanaxClient<K, C, V> {
     public static final String ASTYANAX_CONNECTION_POOL_CONFIGURATION = "astyanax.connectionPoolConfiguration";
     public static final String ASTYANAX_CONNECTION_POOL_MONITOR = "astyanax.connectioPoolMonitor";
     private Map<String, AstyanaxContext<Keyspace>> astyanaxContext = new HashMap<String, AstyanaxContext<Keyspace>>();
-
-
+    public Integer ttl = null;
 
     // not static since we're carting instances around and do not want to share
     // them
@@ -117,6 +116,10 @@ public class AstyanaxClient<K, C, V> {
             	cpConfig.setPort(port.intValue());
             }
         }
+	// set ttl
+	// this coerce-via long business is to handle Integers or longs
+	Long confTtl = (Long) config.get(StormCassandraConstants.CASSANDRA_TTL);
+	ttl = confTtl != null ? confTtl.intValue() : null;
 
         @SuppressWarnings("unchecked")
         Collection<String> keyspaces = (Collection<String>) config.get(StormCassandraConstants.CASSANDRA_KEYSPACE);
@@ -392,8 +395,10 @@ public class AstyanaxClient<K, C, V> {
             TupleMapper<K, C, V> tupleMapper) {
         Map<C, V> columns = tupleMapper.mapToColumns(input);
         for (Map.Entry<C, V> entry : columns.entrySet()) {
-            mutation.withRow(columnFamily, rowKey).putColumn(entry.getKey(), entry.getValue(),
-                    (Serializer<V>) this.serializerFor(tupleMapper.getColumnValueClass()), null);
+            mutation.withRow(columnFamily, rowKey).putColumn(entry.getKey(),
+							     entry.getValue(),
+							     (Serializer<V>) this.serializerFor(tupleMapper.getColumnValueClass()),
+							     ttl);
         }
     }
 
@@ -406,8 +411,10 @@ public class AstyanaxClient<K, C, V> {
             }
         } else {
             for (Map.Entry<C, V> entry : columns.entrySet()) {
-                mutation.withRow(columnFamily, rowKey).putColumn(entry.getKey(), entry.getValue(),
-                        serializerFor(tupleMapper.getColumnValueClass()), null);
+                mutation.withRow(columnFamily, rowKey).putColumn(entry.getKey(),
+								 entry.getValue(),
+								 serializerFor(tupleMapper.getColumnValueClass()),
+								 ttl);
             }
         }
     }


### PR DESCRIPTION
This is motivated by storm bolts writing columns with a TTL. Adds a constant for the TTL config key. TTLs are already supported for e.g. the map state, but via `CassandraMapState$Options`. AFAICT going through the config was the most reasonable way to do it for vanilla storm bolts. The map state would ignore any configured TTL.
